### PR TITLE
Compatible with 2024.1 Removed NVDA+Numpad9 to avoid conflict with NVDA gestures

### DIFF
--- a/addon/globalPlugins/DragAndDrop/__init__.py
+++ b/addon/globalPlugins/DragAndDrop/__init__.py
@@ -252,8 +252,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.kbTimeout.cancel()
 
 	__gestures = {
-	"kb(desktop):NVDA+numpad9": "mouseCursorInfo",
-	"kb(laptop):NVDA+Control+,": "mouseCursorInfo",
+	"kb:NVDA+Control+,": "mouseCursorInfo",
 	"kb:NVDA+,": "selectObjectToDrag",
 	"kb(desktop):NVDA+.": "dragAndDrop",
 	"kb(laptop):NVDA+Shift+,": "dragAndDrop",

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Makes it easy to drag and drop objects."""),
 	# version
-	"addon_version" : "2.2dev",
+	"addon_version" : "2.2.1dev",
 	# Author(s)
 	"addon_author" : u"Javi Dominguez <fjavids@gmail.com>",
 	# URL for the add-on documentation support
@@ -29,7 +29,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0")
 	"addon_minimumNVDAVersion" : None,
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2023.1.0",
+	"addon_lastTestedNVDAVersion" : "2024.1.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
1. Make it compatible with the latest NVDA2024.1
2. Removed `NVDA+NumPad9`, now the command to report mouse information uses the same gesture as laptop layout `NVDA+Ctrl+,`.
